### PR TITLE
Fixed PHP Error: A non-numeric value encountered

### DIFF
--- a/src/Packer.php
+++ b/src/Packer.php
@@ -342,9 +342,9 @@ class Packer
             throw new \InvalidArgumentException("_get_volume function only accepts arrays with 3 values (length, width, height)");
         }
 
-        $box = array_values($box);
-
-        return $box[0] * $box[1] * $box[2];
+        $box = array_filter($box, 'strlen');
+        
+        return (isset($box['length'])?$box['length']:$box[0]) * (isset($box['width'])?$box['width']:$box[1]) * (isset($box['height'])?$box['height']:$box[2]);;
     }
 
     /**


### PR DESCRIPTION
It sends PHP Warning and break execution of functions while boxes have other attributes except length, width, height.
Example: array( [sku] => UNIID,  [weight] => 0.0000, [qty] => 1,[baserowtotal] => 0.0000,[length] => 85,[width] => 3, [height] => 2